### PR TITLE
fix: add public constructor to Location struct

### DIFF
--- a/Classes/PTVStops.swift
+++ b/Classes/PTVStops.swift
@@ -28,6 +28,11 @@ import Foundation
 public struct Location {
     let latitude: Double
     let longitude: Double
+    
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
 }
 
 public extension SwiftPTV {


### PR DESCRIPTION
Hey @evilgoldfish,

I'm working on a menu bar app for timetabling info and came across this gem while in the middle of writing my own PTV API library.

I noticed that I was getting a `'Location' initializer is inaccessible due to 'internal' protection level` error when attempting to instantiate a `Location` struct in my project code to use with the `retrieveStopsNearLocation` function. I added your library via Cocoapods.

I've modified the `Location` struct in the `PTVStops.swift` file to include a public initialiser for the `latitude` and `longitude` properties. This corrects the error I was facing.

Thanks for your work! This library will save me a heap of time!